### PR TITLE
Fix protocol.make request id handling

### DIFF
--- a/pebbling/core/protocol.py
+++ b/pebbling/core/protocol.py
@@ -58,14 +58,19 @@ class pebblingProtocol:
         source_agent_id: str,
         destination_agent_id: str,
         params: Dict[str, Any],
+        request_id: Optional[str] = None,
     ) -> Dict[str, Any]:
-        """Create a protocol message."""
+        """Create a protocol message.
+
+        If ``request_id`` is provided it will be used in the returned message.
+        Otherwise a new UUID4 string is generated.
+        """
         if isinstance(method, ProtocolMethod):
             method = method.value
 
         return {
             "jsonrpc": self.JSONRPC_VERSION,
-            "id": str(uuid.uuid4()),
+            "id": request_id or str(uuid.uuid4()),
             "method": method,
             "source_agent_id": source_agent_id,
             "destination_agent_id": destination_agent_id,
@@ -129,4 +134,5 @@ class pebblingProtocol:
             source_agent_id=source_agent_id,
             destination_agent_id=destination_agent_id,
             params=params,
+            request_id=request_id,
         )

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -117,3 +117,16 @@ class TestPebblingProtocol:
         del invalid_message["source_agent_id"]
 
         assert protocol.validate_message(invalid_message) is False
+
+    def test_make_uses_provided_request_id(self, protocol):
+        """Ensure make() respects an explicitly provided request_id."""
+        request_id = "custom-id"
+        message = protocol.make(
+            method=ProtocolMethod.ACT,
+            source_agent_id="src",
+            destination_agent_id="dest",
+            params={"input": "hi"},
+            request_id=request_id,
+        )
+
+        assert message["id"] == request_id


### PR DESCRIPTION
## Summary
- ensure provided request_id is used when creating protocol messages
- test that make() respects explicit request ids

## Testing
- `ruff check`
- `python -m pytest -q` *(fails: No module named pytest)*