### PR TITLE
Update README line 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ✨ Imagine a world where AI agents collaborate effortlessly and securely—no passport 🚫, no boundaries 🌐.
 
-That’s Pebbling 🐧.An open source, secured protocol fo agent to agent communication.
+That’s Pebbling 🐧.An open source, secured protocol for agent-to-agent communication.
 
 🚀 Powered by Decentralised Identifiers (DIDs) 🔑, secured conversations with mutual TLS (mTLS) 🔒, and a lightweight yet powerful communication protocol built on JSON-RPC 2.0 ⚡️—Pebbling is paving the way for the next generation of collaborative AI systems. 🌟🤖
 


### PR DESCRIPTION
## Summary
- fix a typo in the README text around agent-to-agent communication

## Testing
- `make test` *(fails: No route to host)*